### PR TITLE
UHM-8240 add esm-commons-app to spa config

### DIFF
--- a/spa-build-config.json
+++ b/spa-build-config.json
@@ -1,5 +1,7 @@
 {
   "frontendModules":{
+    "@pih/esm-commons-app":"next",
+
     "@openmrs/esm-active-visits-app": "next",
     "@openmrs/esm-appointments-app": "next",
     "@openmrs/esm-bed-management-app": "next",
@@ -24,7 +26,6 @@
     "@openmrs/esm-patient-flags-app": "next",
     "@openmrs/esm-patient-forms-app": "next",
     "@openmrs/esm-patient-immunizations-app": "next",
-    "@openmrs/esm-patient-labs-app": "next",
     "@openmrs/esm-patient-list-management-app": "next",
     "@openmrs/esm-patient-lists-app": "next",
     "@openmrs/esm-patient-medications-app": "next",
@@ -33,6 +34,7 @@
     "@openmrs/esm-patient-programs-app": "next",
     "@openmrs/esm-patient-registration-app": "next",
     "@openmrs/esm-patient-search-app": "next",
+    "@openmrs/esm-patient-tests-app": "next",
     "@openmrs/esm-patient-vitals-app": "next",
     "@openmrs/esm-primary-navigation-app": "next",
     "@openmrs/esm-service-queues-app": "next",


### PR DESCRIPTION
This PR adds `esm-commons-app` to our list of frontend modules, enabling extensions defined there to be available in esm-ward-app.

Also updated dependency on `esm-patient-labs-app`, which has been renamed to `esm-patient-tests-app`.