### PR TITLE
SL-965 include hotjar for SL training server

### DIFF
--- a/assets/hotjar.js
+++ b/assets/hotjar.js
@@ -1,0 +1,12 @@
+// hotjar is a 3rd party behavioral analytics tool that allows us to record user UI
+// interactions. We enable it at selected training servers
+if("sle-kgh-omrstest.pihelp.org" === window.location.host) {
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:6444833,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+}

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
                             <goal>npx</goal>
                         </goals>
                         <configuration>
-                            <arguments>--legacy-peer-deps openmrs@next build --build-config spa-build-config.json --target target/dist</arguments>
+                            <arguments>--legacy-peer-deps openmrs@next build --asset assets/hotjar.js --build-config spa-build-config.json --target target/dist</arguments>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Testing done:

- Ran `mvn clean install`.
- Copied content of target/dist` to the `frontend` folder of my local openmrs instance
- Ran the instance and go to an O3 page to verify that the `hotjar.js` file is loaded properly