### PR TITLE
UHM-8852 add referral queues app

### DIFF
--- a/spa-build-config.json
+++ b/spa-build-config.json
@@ -1,6 +1,7 @@
 {
   "frontendModules":{
     "@pih/esm-commons-app":"next",
+    "@pih/esm-referrals-queue-app":"next",
 
     "@openmrs/esm-active-visits-app": "next",
     "@openmrs/esm-appointments-app": "next",


### PR DESCRIPTION
This is to consolidate `openmrs-frontend-zl` into this repo. `referrals-queue-app` is the only app that's in ZL but not here.